### PR TITLE
Remove class loader from classes

### DIFF
--- a/lib/qCal/Component.php
+++ b/lib/qCal/Component.php
@@ -309,7 +309,6 @@ abstract class qCal_Component {
 		$component = ucfirst(strtolower($name));
 		$className = "qCal_Component_" . $component;
 		$fileName = str_replace("_", DIRECTORY_SEPARATOR, $className) . ".php";
-		qCal_Loader::loadFile($fileName);
 		$class = new $className($properties);
 		return $class;
 	

--- a/lib/qCal/Property.php
+++ b/lib/qCal/Property.php
@@ -90,9 +90,8 @@ abstract class qCal_Property {
 	static public function factory($name, $value, $params = array()) {
 	
 		$className = self::getClassNameFromPropertyName($name);
-		$fileName = str_replace("_", DIRECTORY_SEPARATOR, $className) . ".php";
+
 		try {
-			qCal_Loader::loadFile($fileName);
 			$class = new $className($value, $params);
 		} catch (qCal_Exception_FileNotFound $e) {
 			// if there is no class available for this property, check if it is non-standard


### PR DESCRIPTION
For my project, I don't use your autoload.php but my own. I removed your version of the class loader from two classes, so there are no conflicts any more.

The calls to your class loader are unnecessary, because the autoloader handles it already.